### PR TITLE
Migrate the deprecated iOS badge API

### DIFF
--- a/flutter_native_badge/CHANGELOG.md
+++ b/flutter_native_badge/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.5+dev
+
+- [iOS] Migrate from the deprecated badge API (#3). 
+  Now `getBadgeCount` in iOS isn't recommended because it depends on the deprecated API and could be unavailable in future iOS releases.
+
 ## 1.0.5 - 5th May 2024
 
 - [iOS] added privacy manifest

--- a/flutter_native_badge/README.md
+++ b/flutter_native_badge/README.md
@@ -63,6 +63,10 @@ FlutterNativeBadge.clearBadgeCount();
 int badgeCount = await FlutterNativeBadge.getBadgeCount();
 ```
 
+For iOS: `getBadgeCount` depends on deprecated API and could be unavailable in future iOS releases!
+There aren't any replacements in iOS SDK.
+If you use `getBadgeCount` now, you had better to consider how to manage the count yourself.
+
 ### Request permission
 
 Each method has a `requestPermission` parameter. If you set it to true, it will request the permission if it is not granted.

--- a/flutter_native_badge/example/lib/main.dart
+++ b/flutter_native_badge/example/lib/main.dart
@@ -28,13 +28,13 @@ class _MyAppState extends State<MyApp> {
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlatformState() async {
     bool isSupported;
-    int badgeCount = 0;
+
     // Platform messages may fail, so we use a try/catch PlatformException.
     // We also handle the message potentially returning null.
     try {
       isSupported = await FlutterNativeBadge.isSupported();
       if (isSupported) {
-        badgeCount = await FlutterNativeBadge.getBadgeCount();
+        await FlutterNativeBadge.clearBadgeCount();
       }
     } on PlatformException {
       isSupported = false;
@@ -47,7 +47,7 @@ class _MyAppState extends State<MyApp> {
 
     setState(() {
       _isSupported = isSupported;
-      _badgeCount = badgeCount;
+      _badgeCount = 0;
     });
   }
 

--- a/flutter_native_badge_foundation/CHANGELOG.md
+++ b/flutter_native_badge_foundation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.4+dev
+
+- [iOS] Migrate from the deprecated badge API (#3). 
+  Now `getBadgeCount` in iOS isn't recommended because it depends on the deprecated API and could be unavailable in future iOS releases.
+
 ## 1.0.4 - 5th May 2024
 
 - [iOS] added privacy manifest

--- a/flutter_native_badge_foundation/example/lib/main.dart
+++ b/flutter_native_badge_foundation/example/lib/main.dart
@@ -32,12 +32,26 @@ class _MyAppState extends State<MyApp> {
     await _platform.requestPermission();
 
     int badgeCount = 0;
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    // We also handle the message potentially returning null.
-    try {
-      badgeCount = await _platform.getBadgeCount();
-    } on PlatformException {
-      badgeCount = 0;
+
+    if (Platform.isIOS) {
+      // getBadgeCount is deprecated in iOS and the current count is unknown.
+      // Manage the count yourself by external datasources if you need to know it.
+      // This example just clears the badge on the launch.
+
+      // Platform messages may fail, so we use a try/catch PlatformException.
+      try {
+        await _platform.clearBadgeCount();
+      } on PlatformException {
+        // Do nothing
+      }
+    } else {
+      // Platform messages may fail, so we use a try/catch PlatformException.
+      // We also handle the message potentially returning null.
+      try {
+        badgeCount = await _platform.getBadgeCount();
+      } on PlatformException {
+        badgeCount = 0;
+      }
     }
 
     // If the widget was removed from the tree while the asynchronous platform

--- a/flutter_native_badge_foundation/ios/Classes/FlutterNativeBadgePlugin.swift
+++ b/flutter_native_badge_foundation/ios/Classes/FlutterNativeBadgePlugin.swift
@@ -25,16 +25,28 @@ public class FlutterNativeBadgePlugin: NSObject, FlutterPlugin, FlutterNativeBad
   }
 
   func getBadgeCount() -> Int64 {
+    // applicationIconBadgeNumber has been deprecated since iOS 17.
+    // There aren't any replacement so this function could be unavailable in future versions. 
     let badgeCount = Int64(UIApplication.shared.applicationIconBadgeNumber)
     return badgeCount
   }
 
   func setBadgeCount(count: Int64) {
-    UIApplication.shared.applicationIconBadgeNumber = Int(truncatingIfNeeded: count)
+    let count = Int(truncatingIfNeeded: count);
+
+    if #available(iOS 16.0, *) {
+      UNUserNotificationCenter.current().setBadgeCount(count)
+    } else {
+      UIApplication.shared.applicationIconBadgeNumber = count
+    }
   }
 
   func clearBadgeCount() {
-    UIApplication.shared.applicationIconBadgeNumber = 0
+    if #available(iOS 16.0, *) {
+      UNUserNotificationCenter.current().setBadgeCount(0)
+    } else {
+      UIApplication.shared.applicationIconBadgeNumber = 0
+    }
   }
 
   func showRedDot() {


### PR DESCRIPTION
Migrate the iOS badge API from deprecated [applicationIconBadgeNumber](https://developer.apple.com/documentation/uikit/uiapplication/1622918-applicationiconbadgenumber) to [setBadgeCount](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/setbadgecount(_:withcompletionhandler:)) and close #3 .

I tested on below environments by `flutter_native_badge_foundation/example`:
- iOS 15.4 (simulator)
- iOS 16.0 (simulator)
- iOS 17.5 (real device)

Should I update documents (at least `CHANGELOG.md` and `README.md`) in this request?
We have better to inform users that `getBadgeCount` could be unavailable in future versions. 

Also the current example uses the getter.
Should I update now or wait until the getter obsoluted?